### PR TITLE
Make dice target own C++17 and test policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,11 @@
-cmake_minimum_required (VERSION 3.1)
-set(CMAKE_CXX_STANDARD 17)
+cmake_minimum_required(VERSION 3.21)
 
-# add options for testing
+project(coda_dice VERSION 0.1.1 LANGUAGES CXX)
+
+option(CODA_BUILD_TESTS "Build libcoda-dice tests." ON)
 option(ENABLE_COVERAGE "Enable code coverage testing." OFF)
 option(ENABLE_MEMCHECK "Enable testing for memory leaks." OFF)
 option(ENABLE_PROFILING "Enable profiling code." OFF)
-
-# define project name
-project (coda_dice VERSION 0.1.1)
-
 
 # set path to custom modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -17,12 +14,13 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(CreatePackages)
 create_packages(DESCRIPTION "A dice rolling utility library")
 
-# Setup testing
-enable_testing()
-
-# add directories
+# add library sources before optional tests
 add_subdirectory(src)
-add_subdirectory(tests)
+
+if(CODA_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
 
 ############################################################
 # Create DEB
@@ -50,4 +48,3 @@ set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
 
 # Include CPack
 include(CPack)
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(${PROJECT_NAME}_YAHT_HEADERS
 )
 
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_HEADERS} ${${PROJECT_NAME}_YAHT_HEADERS} dice.cpp yaht/player.cpp yaht/scoresheet.cpp)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
 string(REPLACE "_" "/" INSTALL_DIRECTORY ${PROJECT_NAME})
 


### PR DESCRIPTION
## Summary

Continues `ryjen/libcoda#2` on the exact dice lineage consumed by the aggregate repo (`feat/bug-fixes`):

- raises the component CMake baseline to 3.21 so target compile features are explicit and supported;
- removes the global `CMAKE_CXX_STANDARD` setting;
- makes `coda_dice` declare `PUBLIC cxx_std_17`;
- adds `CODA_BUILD_TESTS`, defaulting ON standalone while honoring the aggregate parent's cached OFF value;
- avoids configuring Bandit/tests when tests are disabled.

## Scope

Coverage/Valgrind/CPack/install cleanup is intentionally deferred. This slice only removes ambient language/test-policy dependence needed before the aggregate can drop its transitional global C++17 setting.

## Validation

`ryjen/libcoda#13` pins this exact head. Aggregate GitHub Actions run `31797362235` completed successfully with recursive submodule checkout, dependency provisioning, release configure with tests disabled, and the full aggregate release build.

Refs ryjen/libcoda#2
Refs ryjen/libcoda#5
