### PR TITLE
Move dice coverage instrumentation to targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - feat/bug-fixes
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+      - name: Build
+        run: cmake --build build --parallel 2
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  coverage:
+    name: Target-local coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install coverage tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes lcov
+
+      - name: Configure coverage
+        run: |
+          cmake -S . -B build-coverage \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DENABLE_COVERAGE=ON \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+      - name: Build
+        run: cmake --build build-coverage --parallel 2
+
+      - name: Generate coverage report
+        run: cmake --build build-coverage --target coda_dice_coverage
+
+      - name: Verify coverage report
+        run: test -f build-coverage/coverage/index.html

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,9 +34,9 @@ include(ValgrindTest)
 
 add_valgrind_profile_test(MEMCHECK ${ENABLE_MEMCHECK} PROFILING ${ENABLE_PROFILING} TARGET ${TEST_PROJECT_NAME})
 
-# add target for code coverage
 if(ENABLE_COVERAGE)
-	include(CodeCoverage)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_COVERAGE}")
-	setup_target_for_coverage(TARGET ${PROJECT_NAME}_coverage OUTPUT ${PROJECT_BINARY_DIR}/coverage)
+    include(CodaCoverage)
+    coda_enable_target_coverage(TARGET ${PROJECT_NAME})
+    coda_enable_target_coverage(TARGET ${TEST_PROJECT_NAME})
+    setup_target_for_coverage(TARGET ${PROJECT_NAME}_coverage OUTPUT ${PROJECT_BINARY_DIR}/coverage)
 endif()


### PR DESCRIPTION
## Summary

Migrates `libcoda-dice` coverage off global compiler flags using the shared target-local coverage helper:

- removes the `CMAKE_CXX_FLAGS` mutation from the test CMake;
- instruments `coda_dice` and its test executable explicitly with `coda_enable_target_coverage(...)`;
- keeps the existing lcov report-generation target;
- advances the shared `cmake` submodule to merged `ryjen/cmake#3`;
- adds self-cancelling GitHub Actions coverage plus normal build/test gates.

## Validation

GitHub Actions run `31799301903` completed successfully:

- normal configure/build/test: success;
- target-local coverage configure/build/lcov/HTML report generation: success.

The normal job provides the regression boundary showing coverage options are not applied outside the explicit coverage configuration.

Refs ryjen/libcoda#2
Refs ryjen/libcoda#5
